### PR TITLE
Linting tests

### DIFF
--- a/build/package.js
+++ b/build/package.js
@@ -6,7 +6,8 @@ const JSON5 = require('../lib');
 
 const pkg = require('../package.json');
 
-let pkg5 = '// This is a generated file. Do not edit.\n';
-pkg5 += pkg5 = JSON5.stringify(pkg, null, 2);
+const pkg5 = `// This is a generated file. Do not edit.
+${JSON5.stringify(pkg, null, 2)}
+`;
 
 fs.writeFileSync(path.resolve(__dirname, '..', 'package.json5'), pkg5);

--- a/lib/json6.js
+++ b/lib/json6.js
@@ -190,23 +190,23 @@ JSON6.begin = function( cb, reviver ) {
 		completed = false
 		;
 
-	function throwEndError( leader, c ) {
+	function throwEndError( leader /* , c */ ) {
 		throw new Error( `${leader} at ${n} [${pos.line}:${pos.col}]`);
 	}
 
 
 	return {
 		finalError() {
-                	if( comment !== 0 ) { // most of the time everything's good.
-                        	if( comment === 1 ) throwEndError( "Comment began at end of document", 0 );
+			if( comment !== 0 ) { // most of the time everything's good.
+				if( comment === 1 ) throwEndError( "Comment began at end of document", 0 );
 				if( comment === 2 ) console.log( "Warning: '//' comment without end of line ended document" );
 				if( comment === 3 ) throwEndError( "Open comment '/*' is missing close at end of document", 0 );
 				if( comment === 4 ) throwEndError( "Incomplete '/* *' close at end of document", 0 );
-                        }
+			}
 			if( gatheringString ) throwEndError( "Incomplete string", 0 );
 		},
 		value() {
-			this.finalError()
+			this.finalError();
 			var r = result;
 			result = undefined;
 			return r;

--- a/lib/json6.js
+++ b/lib/json6.js
@@ -198,10 +198,17 @@ JSON6.begin = function( cb, reviver ) {
 	return {
 		finalError() {
 			if( comment !== 0 ) { // most of the time everything's good.
-				if( comment === 1 ) throwEndError( "Comment began at end of document", 0 );
-				if( comment === 2 ) console.log( "Warning: '//' comment without end of line ended document" );
-				if( comment === 3 ) throwEndError( "Open comment '/*' is missing close at end of document", 0 );
-				if( comment === 4 ) throwEndError( "Incomplete '/* *' close at end of document", 0 );
+				switch (comment) {
+				case 1:
+					return throwEndError( "Comment began at end of document", 0 );
+				case 2:
+					console.log( "Warning: '//' comment without end of line ended document" );
+					break;
+				case 3:
+					return throwEndError( "Open comment '/*' is missing close at end of document", 0 );
+				case 4:
+					return throwEndError( "Incomplete '/* *' close at end of document", 0 );
+				}
 			}
 			if( gatheringString ) throwEndError( "Incomplete string", 0 );
 		},

--- a/lib/json6.js
+++ b/lib/json6.js
@@ -390,10 +390,10 @@ JSON6.begin = function( cb, reviver ) {
 								throwError( "Incomplete Octal sequence", cInt );
 							else if( stringHex )
 								throwError( "Incomplete hexidecimal sequence", cInt );
-							else if( stringUnicode )
-								throwError( "Incomplete unicode sequence", cInt );
 							else if( unicodeWide )
 								throwError( "Incomplete long unicode sequence", cInt );
+							else if( stringUnicode )
+								throwError( "Incomplete unicode sequence", cInt );
 
 							if( cr_escaped ) {
 								cr_escaped = false; // \\ \r  '  :end string, the backslash was used for \r

--- a/lib/json6.js
+++ b/lib/json6.js
@@ -694,7 +694,7 @@ JSON6.begin = function( cb, reviver ) {
 						else if( comment == 3 ){ // '/*... '
 							if( cInt == 42/*'*'*/ ) comment = 4;
 						}
-						else if( comment == 4 ) { // '/* ... *'
+						else { // if( comment == 4 ) { // '/* ... *'
 							if( cInt == 47/*'/'*/ ) comment = 0;
 							else comment = 3; // any other char, goto expect * to close */
 						}

--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
     "scripts": {
         "lint": "eslint .",
         "build": "node ./lib/cli.js -c package.json6 && rollup -c",
-        "test-cov": "nyc npm test",
-        "test": "mocha --require test/bootstrap/node --recursive"
+        "mocha": "mocha --require test/bootstrap/node --recursive",
+        "nyc": "nyc npm run mocha",
+        "test": "npm run lint && npm run build && npm run nyc"
     },
     "homepage": "http://npmjs.org/package/json-6/",
     "engines": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
         "rollup-plugin-terser": "latest"
     },
     "nyc": {
+        "statements": 97.59,
+        "branches": 95.19,
+        "functions": 100,
+        "lines": 98.03,
         "ignore-class-method": [
             "log"
         ],

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
         "rollup-plugin-terser": "latest"
     },
     "nyc": {
-        "statements": 97.59,
-        "branches": 95.19,
+        "statements": 98.39,
+        "branches": 96.53,
         "functions": 100,
-        "lines": 98.03,
+        "lines": 98.56,
         "ignore-class-method": [
             "log"
         ],

--- a/package.json6
+++ b/package.json6
@@ -38,10 +38,10 @@
       'rollup-plugin-terser': 'latest',
     },
     nyc: {
-        statements: 97.59,
-        branches: 95.19,
+        statements: 98.39,
+        branches: 96.53,
         functions: 100,
-        lines: 98.03,
+        lines: 98.56,
         ignore-class-method: ['log'],
         reporter: [
             'lcov',

--- a/package.json6
+++ b/package.json6
@@ -47,8 +47,9 @@
     scripts: {
         lint: "eslint .",
         build: "node ./lib/cli.js -c package.json6 && rollup -c",
-        'test-cov': 'nyc npm test',
-        test: 'mocha --require test/bootstrap/node --recursive'
+        mocha: 'mocha --require test/bootstrap/node --recursive',
+		nyc: 'nyc npm run mocha',
+		test: 'npm run lint && npm run build && npm run nyc'
     },
     homepage: "http://npmjs.org/package/json-6/",
     engines: {

--- a/package.json6
+++ b/package.json6
@@ -38,6 +38,10 @@
       'rollup-plugin-terser': 'latest',
     },
     nyc: {
+        statements: 97.59,
+        branches: 95.19,
+        functions: 100,
+        lines: 98.03,
         ignore-class-method: ['log'],
         reporter: [
             'lcov',

--- a/test/json6BadTest.js
+++ b/test/json6BadTest.js
@@ -5,15 +5,6 @@ var parse = JSON6.parse;
 var o;
 
 describe('Bad tests', function () {
-
-	/*
-	it('Unquoted keyword', function () {
-		expect(function () {
-			o = parse( "{ true:1 }" );
-			console.log( "got back:", o );
-		}).to.throw(Error);
-	});
-	*/
 	it('Non-matching keyword (true)', function () {
 		expect(function () {
 			o = parse( "tt" );

--- a/test/json6Test.js
+++ b/test/json6Test.js
@@ -107,10 +107,25 @@ describe('Basic parsing', function () {
 		});
 	});
 	describe('Comments', function () {
-		it('Should throw with incomplete comment', function () {
+		it('Should throw with invalid comment', function () {
 			expect(function () {
 				parse( "/a" );
 			}).to.throw(Error);
+		});
+		it('Should throw with incomplete comment (single slash)', function () {
+			expect(function () {
+				parse( "/" );
+			}).to.throw(Error);
+		});
+		it('Should throw with incomplete comment (closing asterisk)', function () {
+			expect(function () {
+				parse( "/* *" );
+			}).to.throw(Error);
+		});
+		it('Should not err (will warn) with comment begun at end', function () {
+			var o = parse( "//" );
+			console.log( "o is", o, typeof o );
+			expect(o).to.equal(undefined);
 		});
 		it('Should throw with incomplete comment with 2 asterisks', function () {
 			expect(function () {

--- a/test/json6Test.js
+++ b/test/json6Test.js
@@ -228,6 +228,16 @@ describe('Basic parsing', function () {
 				console.log( "o is", o );
 				expect(o).to.deep.equal({ a: 'abcdef' });
 			});
+			it('Unquoted keyword (true)', function () {
+				var o = parse( "{ true:1 }" );
+				console.log( "o is", o );
+				expect(o).to.deep.equal({ true: 1 });
+			});
+			it('Unquoted keyword (null)', function () {
+				var o = parse( "{ null:1 }" );
+				console.log( "o is", o );
+				expect(o).to.deep.equal({ null: 1 });
+			});
 		});
 	});
 	describe('Arrays', function () {

--- a/test/stringEscapes.js
+++ b/test/stringEscapes.js
@@ -33,6 +33,12 @@ describe('String escapes', function () {
 				JSON6.parse( '"\\u{00G}"' );
 			}).to.throw(Error, /escaped character, parsing hex/);
 		});
+
+		it('Throws with incomplete Unicode wide escape (upper-case)', function () {
+			expect(function () {
+				JSON6.parse( '"\\u{00F"' );
+			}).to.throw(Error, /Incomplete long unicode sequence/);
+		});
 	});
 	describe('String hex escapes', function () {
 		it('Parses string hex', function () {

--- a/test/stringEscapes.js
+++ b/test/stringEscapes.js
@@ -65,5 +65,11 @@ describe('String escapes', function () {
 				JSON6.parse( '"\\"' );
 			}).to.throw(Error);
 		});
+
+		it('should recover with carriage return escape at end of string', function () {
+			var o = JSON6.parse( '"\\\r"' );
+			console.log( "o is", o, typeof o );
+			expect(o).to.equal('\r');
+		});
 	});
 });

--- a/test/testIncompleteStringEscapes.js
+++ b/test/testIncompleteStringEscapes.js
@@ -1,5 +1,6 @@
+'use strict';
 
-var JSON6 = require( ".." )
+var JSON6 = require( ".." );
 
 var parse = JSON6.parse;
 var o;


### PR DESCRIPTION
- Fix: Ensure long unicode-specific check occurs before regular unicode matches it
- Refactor: Use constant ES6 template in place of accumulated `let`
- Refactor: Use switch to clarify paths are not successive
- Refactor: Avoid unreachable alternate branch for `if` (for coverage)
- Linting: Comment out unused variable; mixed tabs/spaces; missing semicolons and "use strict"
- Testing: Ensure Linting and coverage are run in `test` for CI (though provide `mocha` and `nyc` scripts for development)
- Testing: Temporarily Add thresholds matching current percentages (to ensure not regressing in coverage until we may get to 100%)
- Testing: Add (positive) unquoted keyword tests
- Testing: Invalid comments
- Testing: Incomplete Unicode wide escape

Btw, there seems to be one regression, though not reflected in tests. For some reason, when the `package.json` file is built, it adds a section about `rollup-plugin-terser` which I don't see any reason it should be built. But I'd appreciate if you could look at this short PR first as I think the testing procedures here ought to be helpful in preventing some regressions going forward (at least if CI is heeded; one could also add a commit hook to lint there if you like).