### PR TITLE
- Testing: Add test for trailing comma

### DIFF
--- a/test/json6Test.js
+++ b/test/json6Test.js
@@ -282,6 +282,20 @@ describe('Basic parsing', function () {
 				expect(o).to.deep.equal({ null: 1 });
 			});
 		});
+
+		it('Handles trailing commas', function () {
+			var o = parse(`{
+				    abc: {
+				      'a': 5,
+				    }
+				}`);
+			console.log( "o is", o );
+			expect(o).to.deep.equal({
+			    abc: {
+			      a: 5,
+			    }
+			});
+		});
 	});
 	describe('Arrays', function () {
 		it('Simple array', function () {


### PR DESCRIPTION
Adds a test for trailing commas.

However, this test is currently failing (and shouldn't).

It's adding to the expected object as follows:

```diff
{
+        "a": {
+          "a": 5
+        }
         "abc": {
           "a": 5
         }
       }
```