### PR TITLE
Prepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         ]
     },
     "scripts": {
+        "prepack": "npm run test-lite",
         "lint": "eslint --cache .",
         "build": "node ./lib/cli.js -c package.json6 && rollup -c",
         "mocha-lite": "mocha --require test/bootstrap/node",

--- a/package.json6
+++ b/package.json6
@@ -50,6 +50,7 @@
         ]
     },
     scripts: {
+        prepack: "npm run test-lite",
         lint: "eslint --cache .",
         build: "node ./lib/cli.js -c package.json6 && rollup -c",
         'mocha-lite': 'mocha --require test/bootstrap/node',

--- a/test/json6Test.js
+++ b/test/json6Test.js
@@ -282,7 +282,7 @@ describe('Basic parsing', function () {
 				expect(o).to.deep.equal({ null: 1 });
 			});
 			it('Handles trailing commas', function () {
-				var o = parse(`{
+				const o = parse(`{
 					    abc: {
 					      'a': 5,
 					    }
@@ -293,11 +293,11 @@ describe('Basic parsing', function () {
 				      a: 5,
 				    }
 				});
-			});		
+			});
 		});
 
 		it('Handles trailing commas', function () {
-			var o = parse(`{
+			const o = parse(`{
 				    abc: {
 				      'a': 5,
 				    }


### PR DESCRIPTION
- npm: Add `prepack` script to run `test-lite` (per https://github.com/d3x0r/JSON6/issues/34#issuecomment-634228709 )
- Linting: Prefer `const` (these linting errors weren't caught because the PR that added them was merged before the `linting-pkg-json` merge and only changes are linted; going forward, future linting errors should be caught)

Btw, if you are only looking to see the files that are changed, it may be simpler to just run `npm publish --dry-run`. If you don't actually need `pack`, we could change the script where it runs to [`prepublishOnly`](https://docs.npmjs.com/misc/scripts).