### PR TITLE
feat: throws on non-ES-strict-mode-compatible behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,9 @@ JavaScript-subset guarantee can turn on [`esStrictCompatible`](#options).
           ends the document without a line break (now silent by default).
     - `stringify` gains an opt-out `sortKeys` option (and a matching `sortKeys` property on
       `JSON6.stringifier()`); default `true` preserves the historical sorted-key output.
+    - `esStrictCompatible` no longer rejects two inputs that are valid ES strict mode:
+      a literal U+2028/U+2029 inside a `'`/`"` string (legal since ES2019), and an
+      unquoted numeric key using a numeric separator (`{1_000:1}`).
 - 1.1.5
     - TypeScript declarations are generated from JSDoc during `npm run build` and shipped in `dist/` (#55).
     - ESM loader for `.json6` moved to the `module.register()` API; `lib/register.mjs` added.

--- a/README.md
+++ b/README.md
@@ -301,6 +301,12 @@ code are always strict; constructs that are legal only in "sloppy" mode (the
 legacy octal escape `"\1"`, or `"\9"` which sloppy mode silently reduces to
 `"9"`) are still rejected by `esStrictCompatible`.
 
+A numeric object key keeps its source text rather than JavaScript's normalized
+form, so `{1e3:1}` gives the key `"1e3"` here but `"1000"` in JavaScript (where
+a NumericLiteral key is converted through its numeric value). This applies
+under `esStrictCompatible` too: the "same meaning when pasted" guarantee is
+about what parses, not about the exact key string produced by each parser.
+
 ```js
 JSON6.parse("{'a-b': 0123}");                                        // { 'a-b': 123 }  (default)
 JSON6.parse("{'a-b': 0123}", null, { esStrictCompatible: true });    // throws

--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ JSON6 includes all features of JSON5 plus the following.
   - Arrays - empty members
   - Streaming reader interface
   - (Twice the speed of JSON5; subjective)
+  - Opt-in [`esStrictCompatible`](#options) mode that narrows the grammar to a subset of ECMAScript strict mode (see [Why might you wish to enable ECMAScript compatibility?](#why-might-you-wish-to-enable-ecmascript-compatibility)).
 
 ### Objects
 
-- Object keys can be unquoted if they do not have ':', ']', '[', '{', '}', ',', any quote or whitespace; keywords will be interpreted as strings.
+- Object keys can be unquoted if they do not have ':', ']', '[', '{', '}', ',', any quote or whitespace; keywords will be interpreted as strings.  Under the opt-in [`esStrictCompatible`](#options) mode an unquoted key must additionally be a valid ECMAScript identifier name (or a number), so characters such as `-`, `\`, `&`, `+`, `*` and `|` then require quoting.
 
-- Object keys can be single-quoted, (**JSON6**) or back-tick quoted; any valid string
+- Object keys can be single-quoted, (**JSON6**) or back-tick quoted (the latter is rejected under [`esStrictCompatible`](#options)); any valid string
 
 - Object keys can be double-quoted (original JSON).
 
@@ -99,10 +100,13 @@ JSON6 includes all features of JSON5 plus the following.
 - Strings can be split across multiple lines; just prefix each newline with a
   backslash. [ES5 [§7.8.4](http://es5.github.com/#x7.8.4)]
 
-- (**JSON6**) all strings will continue keeping every character between the start and end, this allows multi-line strings
-  and keep the newlines in the string; if you do not want the newlines they can be escaped as previously mentioned.
+- (**JSON6**) all strings keep every character between the start and end, so single-, double-, and
+  back-tick-quoted strings may all span multiple lines with the newlines preserved.  If you do not want the
+  newlines they can be escaped as previously mentioned.  (Under the opt-in [`esStrictCompatible`](#options)
+  mode a literal, unescaped line terminator is rejected inside `'`/`"` strings — but still allowed inside
+  back-ticks — so those strings stay valid ECMAScript.)
 
-- (**JSON5+?**) Strings can have characters emitted using 1 byte hex, interpreted as a utf8 codepoint `\xNN`, 2 and only 2 hex digits must follow `\x`; they may be 4 byte unicode characters `\uUUUU`, 4 and only 4 hex digits must follow `\u`; higher codepoints can be specified with `\u{HHHHH}`, (where H is a hex digit) This is permissive and may accept a single hex digit between `{` and `}`.  All other standard escape sequeneces are also recognized.  Any character that is not recognized as a valid escape character is emitted without the leading escape slash ( for example, `"\012"` will parse as `"012"`
+- (**JSON5+?**) Strings can have characters emitted using 1 byte hex, interpreted as a utf8 codepoint `\xNN`, 2 and only 2 hex digits must follow `\x`; they may be 4 byte unicode characters `\uUUUU`, 4 and only 4 hex digits must follow `\u`; higher codepoints can be specified with `\u{HHHHH}`, (where H is a hex digit) This is permissive and may accept a single hex digit between `{` and `}`.  All other standard escape sequeneces are also recognized.  Any character that is not recognized as a valid escape character is emitted without the leading escape slash ( for example, `"\012"` will parse as `"\0" + "12"`).  (Under the opt-in [`esStrictCompatible`](#options) mode a legacy octal escape such as `"\012"` or `"\1"` is rejected.)
 
 - (**JSON6**) The interpretation of newline is dynamic treating `\r`, `\n`, and `\r\n` as valid combinations of line ending whitespace.  The `\` will behave approrpriately on those combinations.  Mixed line endings like `\n\r?` or `\n\r\n?` are two line endings; 1 for newline, 1 for the \r(follwed by any character), and 1 for the newline, and 1 for the \r\n pair in the second case.
 
@@ -116,7 +120,7 @@ JSON6 includes all features of JSON5 plus the following.
 
 - (**JSON6**) Numbers can be octal (base 8).  (0o prefix)
 
-- (**JSON6**) Decimal Numbers can have leading zeros.  (0 prefix followed by more numbers, without a decimal)  `0123` is `123`, not octal `83`; see [Leading 0 Octal](#leading-0-octal).
+- (**JSON6**) Decimal Numbers can have leading zeros.  (0 prefix followed by more numbers, without a decimal)  `0123` is `123`, not octal `83`; see [Leading 0 Octal](#leading-0-octal).  (Rejected under the opt-in [`esStrictCompatible`](#options) mode, where ECMAScript treats it as legacy octal.)
 
 - Numbers can begin or end with a (leading or trailing) decimal point.
 
@@ -124,7 +128,7 @@ JSON6 includes all features of JSON5 plus the following.
 
 - Numbers can begin with an explicit plus sign.
 
-- Numbers can begin with multiple minus signs. For example '----123' === 123.
+- (**JSON6**) Numbers can begin with multiple minus signs (for example `'----123' === 123`).  (Two or more consecutive signs are rejected under the opt-in [`esStrictCompatible`](#options) mode.)
 
 ### Keyword Values
 
@@ -134,7 +138,7 @@ JSON6 includes all features of JSON5 plus the following.
 ### Comments
 
 - Both inline (single-line using '//' (todo:or '#'?) ) and block (multi-line using \/\* \*\/ ) comments are allowed.
-  - `//` comments end at a `\r` or `\n` character; They MAY also end at the end of a document, although a warning is issued at this time.
+  - `//` comments end at a `\r` or `\n` character; They MAY also end at the end of a document (pass `{ warnWithCommentWithoutEOL: true }` to log a warning when that happens).
   - `/*` comments should be closed before the end of a document or stream flush.
   - `/` followed by anything else other than `/` or `*` is an error.
 
@@ -265,14 +269,108 @@ var str = JSON6.stringify(obj); /* uses JSON stringify, so don't have to replace
 
 |JSON6 Methods | parameters | Description |
 |-----|-----|-----|
-|parse| (string [,reviver]) | supports all of the JSON6 features listed above, as well as the native [`reviver` argument][json-parse]. |
+|parse| (string [,reviver] [,options]) | supports all of the JSON6 features listed above, as well as the native [`reviver` argument][json-parse]. See [Options](#options) for `options`. |
 |stringify | ( value ) | converts object to JSON.  [stringify][json-stringify] |
 |escape | ( string ) | substitutes ", \, ', and ` with backslashed sequences. (prevent 'JSON injection') |
-|begin| (cb [,reviver] ) | create a JSON6 stream processor.  cb is called with (value) for each value decoded from input given with write().  Optional reviver is called with each object before being passed to callback. |
+|begin| (cb [,reviver] [,options] ) | create a JSON6 stream processor.  cb is called with (value) for each value decoded from input given with write().  Optional reviver is called with each object before being passed to callback. `options` are the same as for `parse` and stay in effect across a bare `reset()`. |
 
+### Options
+
+`parse`, `begin`, and `reset` take an optional trailing `options` object.
+**Every option is off by default**, so out of the box JSON6 accepts its full
+historical grammar.
+
+| Option | Default | Effect |
+|:---|:---|:---|
+| `esStrictCompatible` | `false` | When `true`, narrow the accepted grammar to a subset of **ECMAScript strict mode**, so anything that parses can be pasted into a module or `eval`'d unchanged (if trusted or using `forbidTemplateSubstitution: true`). Rejects: legacy-octal / leading-zero numbers (`0123`); legacy octal string escapes (`"\012"`, `"\1"`..`"\9"`); literal (unescaped) line terminators inside `'`/`"` strings — back-tick strings still allow them; back-tick-quoted object keys; unquoted object keys that are neither identifiers nor numbers (`{a-b: 1}`); and two or more consecutive unary `+`/`-` signs (`--5`). |
+| `forbidTemplateSubstitution` | `false` | When `true`, reject an unescaped `${` inside a back-tick-quoted string, so a document cannot silently turn into a template-literal substitution if it is later evaluated as JavaScript. Independent of `esStrictCompatible`. |
+| `warnWithCommentWithoutEOL` | `false` | When `true`, a `//` comment that runs to the end of the document with no terminating line break logs a `console` warning. The input is accepted either way. |
+
+Strict mode is the yardstick because modules, classes, and any `"use strict"`
+code are always strict; constructs that are legal only in "sloppy" mode (the
+legacy octal escape `"\1"`, or `"\9"` which sloppy mode silently reduces to
+`"9"`) are still rejected by `esStrictCompatible`.
+
+```js
+JSON6.parse("{'a-b': 0123}");                                        // { 'a-b': 123 }  (default)
+JSON6.parse("{'a-b': 0123}", null, { esStrictCompatible: true });    // throws
+JSON6.parse("`total: ${x}`");                                        // 'total: ${x}'  (default)
+JSON6.parse("`total: ${x}`", null, { forbidTemplateSubstitution: true }); // throws
+```
+
+`begin(cb, reviver, options)` applies the options to the stream; a bare
+`reset()` keeps them, while `reset(options)` replaces them.
 
 [json-parse]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse
 [json-stringify]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+
+#### Why the default is *not* strict
+
+The extensions exist because they make hand-written data less noisy, and for
+a data format — which is read and edited far more than it is pasted into
+code — that often matters more than JavaScript-parseability:
+
+- **Leading zeros align columns.** `[ 001, 002, 010, 100 ]` or a table of
+  `id: 0042` reads better than ragged values. `Number()` already treats
+  `"0123"` as `123`, so nothing is ambiguous; only a *source-code lexer*
+  would see octal. (See [Leading 0 Octal](#leading-0-octal).)
+- **Literal newlines in ordinary strings are the obvious behavior.** Most
+  people expect a quote to keep running until the closing quote; requiring a
+  trailing `\` on every line, or switching to back-ticks, is friction with no
+  payoff when the file is never going to be executed.
+- **Punctuation in unquoted keys.** `content-type`, `x-api-key`,
+  `feature.flag` and the like are extremely common config keys; quoting every
+  one of them is the exact verbosity JSON6 set out to remove.
+- **`--5`, `+8`, stray signs.** Forgiving sign handling means
+  machine-generated output and quick hand edits parse without complaint.
+- **`${...}` as plain text.** In a data file there is no interpolation to
+  worry about, so `` `price: ${amount}` `` is just a string; forbidding it
+  only helps if the file will later be evaluated as code.
+
+If a given file (or project) is meant to double as JavaScript, turn on
+`esStrictCompatible` and the parser will hold it to that stricter bar;
+otherwise the friendlier grammar is the point.
+
+#### Why might you wish to enable ECMAScript compatibility?
+
+JSON6 offers the potential for a `.json6` document to also be a valid
+JavaScript value literal. Turning on `esStrictCompatible` keeps that true
+in every context, and that can buy a lot:
+
+- **Paste-compatibility, both directions.** You can copy a logged object
+  (`console.log(obj)`) straight into a `.json6` file, and paste a `.json6`
+  file into a `.js` module, `eval` it, or rename it to a JS config
+  (`module.exports = { … }`) without edits or `SyntaxError`s. A config
+  authored in JSON6 can "graduate" to a real JS module the day it needs a
+  computed value.
+- **No silent changes of meaning.** The dangerous cases aren't the ones that
+  error — they're the ones that don't. `0123` is `123` in JSON6 but octal
+  `83` in sloppy JS; `` `total: ${x}` `` is a literal string here but a
+  substitution in JS; `--5` is `5` here but decrement-nonsense elsewhere. An
+  ES-compatible subset removes these by construction.
+- **Existing tooling just works.** Editors, syntax highlighters, bracket
+  matchers, Prettier, ESLint, and AST libraries (acorn, Babel, TypeScript)
+  already understand ES. If `.json6` is an ES subset, all of that applies for
+  free, and authors of new tools that touch `.json6` are far less likely to
+  get an edge case subtly wrong.
+- **Familiarity, not a new dialect.** Developers already know the rules;
+  there is no "…but JSON6 also allows backtick keys and `&` in identifiers"
+  to learn, and fewer typos that happen to parse as something unintended.
+- **Interoperability instead of fragmentation.** Other parsers in the
+  ecosystem (e.g. `eslint-plugin-jsonc`, which already reads some JSON6) can
+  be built on an ES grammar; every deviation is a place two implementations
+  can disagree.
+- **Forward compatibility.** TC39 periodically assigns meaning to
+  previously-free syntax. A grammar that stays inside today's ES is less
+  likely to collide with tomorrow's. JSON itself learned this: the
+  U+2028/U+2029 portability bug was fixed in ES2019 by making JSON a
+  syntactic subset of ES.
+- **It's the direction the standards went.** The accepted
+  [tc39 JSON-superset proposal](https://github.com/tc39/proposal-json-superset)
+  made the same argument from the other side.
+- **Cheaper correctness.** The parser can be checked against a reference: if
+  V8/`acorn` accepts the text and produces value *v*, JSON6 should too. A
+  narrower grammar is also less to audit.
 
 ### JSON6 Streaming
 
@@ -285,7 +383,7 @@ A Parser that returns objects as they are encountered in a stream can be created
 | write | (string) | Parse string passed and as objects are found, invoke the callback passed to `begin()` Objects are passed through optional reviver function passed to `begin()`. |
 | \_write | (string,completeAtEnd) | Low level routine used internally.  This does the work of parsing the passed string. Returns 0 if no object completed, 1 if there is no more data, and an object was completd, returns 2 if there is more data and a parsed object is found.  if completedAtEnd is true, dangling values are returned, for example "1234" isn't known to be completed, more of the number might follow in another buffer; if completeAtEnd is passed, this iwll return as number 1234.  Passing empty arguments steps to the next buffered input value. |
 | value | () | Returns the currently completed object.  Used to get the completed object after calling \_write. |
-| reset | () | If `write()` or `\_write()` throws an exception, no further objects will be parsed becuase internal status is false, this resets the internal status to allow continuing using the existing parser.  ( May require some work to actually work for complex cases) |
+| reset | ( [options] ) | If `write()` or `\_write()` throws an exception, no further objects will be parsed becuase internal status is false, this resets the internal status to allow continuing using the existing parser.  ( May require some work to actually work for complex cases)  With no argument the options passed to `begin()` stay in effect; pass an `options` object to change them. |
 
 
 ```js
@@ -425,7 +523,7 @@ The product of this should run on very old platforms also, especially `node_modu
 
 ## Leading 0 Octal
 
-A number with a leading `0` followed by more digits is decimal.  `0123` is `123`.  It is not octal (`83`), and it is not an error.
+A number with a leading `0` followed by more digits is decimal.  `0123` is `123`.  It is not octal (`83`), and it is not an error.  (The opt-in [`esStrictCompatible`](#options) mode is the exception: it rejects the token, matching ECMAScript strict mode.)
 
 The rationale: JSON6 is a data format, not source code.  The leading-zero-means-octal convention lives in
 *source code lexers* (C, C++, Java, Perl, Ruby, Go, shell, Python 2, sloppy-mode JavaScript).  Every
@@ -450,7 +548,8 @@ The alternatives were considered and rejected:
 
 This is a deliberate divergence from ECMAScript strict mode, where `0123` is a syntax error.  A `.json6`
 document that uses leading zeros is therefore not valid JavaScript source; the same is true of JSON6's
-other extensions.  [JSOX](https://github.com/d3x0r/JSOX) takes the same stance.
+other extensions.  [JSOX](https://github.com/d3x0r/JSOX) takes the same stance.  Callers who need the
+JavaScript-subset guarantee can turn on [`esStrictCompatible`](#options).
 
 ## Changelog
 - 1.1.6(pre)
@@ -467,6 +566,15 @@ other extensions.  [JSOX](https://github.com/d3x0r/JSOX) takes the same stance.
     - `parse()` restores its nested-parser level when it throws.
     - Vertical tab (U+000B), form feed (U+000C), line separator (U+2028) and paragraph separator (U+2029) are whitespace between tokens, as in ECMAScript; U+2028/U+2029 also end a `//` comment.
     - Remove no stringifier cavaet from documentation.
+    - `parse` / `begin` / `reset` now take an `options` argument ([#46](https://github.com/d3x0r/JSON6/issues/46)).
+      All options are off by default, so the historical grammar is unchanged.
+        - `esStrictCompatible` restricts the grammar to a subset of ECMAScript strict mode:
+          it rejects leading-zero / legacy-octal numbers, legacy octal string escapes
+          (`"\1"`..`"\9"`), literal line terminators inside `'`/`"` strings, backtick-quoted
+          object keys, non-identifier unquoted keys, and two or more consecutive `+`/`-` signs.
+        - `forbidTemplateSubstitution` rejects an unescaped `${` inside a backtick string.
+        - `warnWithCommentWithoutEOL` restores the console warning for a `//` comment that
+          ends the document without a line break (now silent by default).
 - 1.1.5
     - TypeScript declarations are generated from JSDoc during `npm run build` and shipped in `dist/` (#55).
     - ESM loader for `.json6` moved to the `module.register()` API; `lib/register.mjs` added.

--- a/README.md
+++ b/README.md
@@ -270,9 +270,19 @@ var str = JSON6.stringify(obj); /* uses JSON stringify, so don't have to replace
 |JSON6 Methods | parameters | Description |
 |-----|-----|-----|
 |parse| (string [,reviver] [,options]) | supports all of the JSON6 features listed above, as well as the native [`reviver` argument][json-parse]. See [Options](#options) for `options`. |
-|stringify | ( value ) | converts object to JSON.  [stringify][json-stringify] |
+|stringify | (value [,replacer] [,space] [,options]) | converts object to JSON.  [stringify][json-stringify]. `options.sortKeys` (default `true`) can be set to `false` to keep an object's own key order instead of sorting it. |
 |escape | ( string ) | substitutes ", \, ', and ` with backslashed sequences. (prevent 'JSON injection') |
 |begin| (cb [,reviver] [,options] ) | create a JSON6 stream processor.  cb is called with (value) for each value decoded from input given with write().  Optional reviver is called with each object before being passed to callback. `options` are the same as for `parse` and stay in effect across a bare `reset()`. |
+
+`JSON6.stringifier()` returns a reusable stringifier object whose `sortKeys`
+(default `true`) and `ignoreNonEnumerable` (default `false`) properties can
+also be set directly:
+
+```js
+const stringifier = JSON6.stringifier();
+stringifier.sortKeys = false;
+stringifier.stringify({ z: 1, a: 2 }); // '{z:1,a:2}' -- own key order kept
+```
 
 ### Options
 
@@ -575,6 +585,8 @@ JavaScript-subset guarantee can turn on [`esStrictCompatible`](#options).
         - `forbidTemplateSubstitution` rejects an unescaped `${` inside a backtick string.
         - `warnWithCommentWithoutEOL` restores the console warning for a `//` comment that
           ends the document without a line break (now silent by default).
+    - `stringify` gains an opt-out `sortKeys` option (and a matching `sortKeys` property on
+      `JSON6.stringifier()`); default `true` preserves the historical sorted-key output.
 - 1.1.5
     - TypeScript declarations are generated from JSDoc during `npm run build` and shipped in `dist/` (#55).
     - ESM loader for `.json6` moved to the `module.register()` API; `lib/register.mjs` added.

--- a/lib/json6.js
+++ b/lib/json6.js
@@ -68,6 +68,11 @@ const CONTEXT_OBJECT_FIELD_VALUE = 4;
 // not accept.
 const ES_IDENTIFIER_NAME = /^[$_\p{ID_Start}][$_\p{ID_Continue}]*$/u;
 
+// Matches a NumericLiteralSeparator ('_') only where it is legal: between two
+// digits. Used only by `esStrictCompatible` to recognize unquoted numeric keys
+// like `1_000` as valid JS -- `Number()` itself rejects the underscore.
+const NUMERIC_SEPARATOR = /(\d)_(?=\d)/g;
+
 /**
  * @typedef {{
  *   n: number,
@@ -1019,7 +1024,7 @@ JSON6.begin = function( cb, reviver, options ) {
 							word = WORD_POS_RESET;
 							if( esStrictCompatible && val.value_type !== VALUE_STRING
 								&& !ES_IDENTIFIER_NAME.test( val.string )
-								&& Number.isNaN( Number( val.string ) ) )
+								&& Number.isNaN( Number( val.string.replace( NUMERIC_SEPARATOR, '$1' ) ) ) )
 								throwError( "Unquoted keys must be valid identifiers when the 'esStrictCompatible' option is set", cInt );
 							val.name = val.string;
 							val.string = '';

--- a/lib/json6.js
+++ b/lib/json6.js
@@ -1519,6 +1519,7 @@ JSON6.parse = function( msg, reviver, options ) {
  * @property {(o?: unknown, r?: Json6Replacer, s?: string|number|null, as?: string) => string|undefined} stringify
  * @property {(q: string) => void} setQuote
  * @property {boolean} ignoreNonEnumerable
+ * @property {boolean} sortKeys
  */
 
 /** @type {Json6Stringifier|null} */
@@ -1528,6 +1529,9 @@ JSON6.stringifier = function() {
 	let useQuote = '"';
 
 	let ignoreNonEnumerable = false;
+	// preserves the historical (sorted) output by default; set to `false` to
+	// emit keys in their own enumeration order instead.
+	let sortKeys = true;
 
 	return {
 		/**
@@ -1544,6 +1548,8 @@ JSON6.stringifier = function() {
 		setQuote(q) { useQuote = q; },
 		get ignoreNonEnumerable() { return ignoreNonEnumerable; },
 		set ignoreNonEnumerable(val) { ignoreNonEnumerable = val; },
+		get sortKeys() { return sortKeys; },
+		set sortKeys(val) { sortKeys = val; },
 	};
 
 	/**
@@ -1731,16 +1737,20 @@ JSON6.stringifier = function() {
 								continue;
 							}
 
-						// sort properties into keys.
 						if (Object.prototype.hasOwnProperty.call(record, k)) {
-							let n;
-							for( n = 0; n < keys.length; n++ )
-								if( keys[n] > k ) {
-									keys.splice(n,0,k );
-									break;
-								}
-							if( n === keys.length )
+							if( sortKeys ) {
+								// sort properties into keys.
+								let n;
+								for( n = 0; n < keys.length; n++ )
+									if( keys[n] > k ) {
+										keys.splice(n,0,k );
+										break;
+									}
+								if( n === keys.length )
+									keys.push(k);
+							} else {
 								keys.push(k);
+							}
 						}
 					}
 					//_DEBUG_STRINGIFY && console.log( "Expanding object keys:", v, keys );
@@ -1779,13 +1789,21 @@ JSON6.stringifier = function() {
 };
 
 /**
+ * @typedef {object} Json6StringifyOptions
+ * @property {boolean} [sortKeys] When `false`, object keys are emitted in their
+ *   own enumeration order instead of sorted. Defaults to `true`.
+ */
+
+/**
  * @param {unknown} object
  * @param {Json6Replacer} [replacer]
  * @param {string|number} [space]
+ * @param {Json6StringifyOptions} [options]
  * @returns {string|undefined}
  */
-JSON6.stringify = function( object, replacer, space ) {
+JSON6.stringify = function( object, replacer, space, options ) {
 	const stringifier = JSON6.stringifier();
+	if( options && options.sortKeys === false ) stringifier.sortKeys = false;
 	return stringifier.stringify( object, replacer, space );
 };
 

--- a/lib/json6.js
+++ b/lib/json6.js
@@ -762,8 +762,9 @@ JSON6.begin = function( cb, reviver, options ) {
 						dollarSeen = false;
 					}
 					else {
-						if( strictQuote
-							&& ( cInt === 10/*'\n'*/ || cInt === 13/*'\r'*/ || cInt === 0x2028 || cInt === 0x2029 ) )
+						// U+2028/U+2029 are legal, unescaped, inside string literals since
+						// ES2019 (the JSON-superset proposal); only \n and \r are illegal.
+						if( strictQuote && ( cInt === 10/*'\n'*/ || cInt === 13/*'\r'*/ ) )
 							throwError( "Literal line terminators inside single- or double-quoted strings require the 'esStrictCompatible' option to be off", cInt );
 						if( trackTemplate ) {
 							if( dollarSeen && cInt === 123/*'{'*/ )

--- a/lib/json6.js
+++ b/lib/json6.js
@@ -62,11 +62,39 @@ const CONTEXT_IN_ARRAY = 1;
 const CONTEXT_OBJECT_FIELD = 3;
 const CONTEXT_OBJECT_FIELD_VALUE = 4;
 
+// Matches an ECMAScript `IdentifierName` (the production that may appear
+// unquoted as an object-literal property key in JavaScript). Used only by the
+// opt-in `esStrictCompatible` mode to reject unquoted keys JavaScript would
+// not accept.
+const ES_IDENTIFIER_NAME = /^[$_\p{ID_Start}][$_\p{ID_Continue}]*$/u;
+
 /**
  * @typedef {{
  *   n: number,
  *   buf: null|string
  * }} Json6Node
+ */
+
+/**
+ * Options accepted by {@link JSON6.parse} and {@link JSON6.begin}. All are
+ * off by default: with no options JSON6 accepts its full historical grammar.
+ *
+ * @typedef {object} Json6ParseOptions
+ * @property {boolean} [esStrictCompatible] When `true`, reject the JSON6
+ *   extensions that are not valid in ECMAScript strict mode, so accepted
+ *   input can be pasted into a module or `eval`'d unchanged: legacy-octal /
+ *   leading-zero numbers (`0123`); legacy octal string escapes (`"\012"`,
+ *   `"\1"`..`"\9"`); literal line terminators inside `'`/`"` strings
+ *   (backtick strings still allow them); backtick-quoted object keys;
+ *   unquoted object keys that are neither identifiers nor numbers; and two or
+ *   more consecutive unary `+`/`-` signs. Defaults to `false`.
+ * @property {boolean} [forbidTemplateSubstitution] When `true`, reject an
+ *   unescaped `${` inside a backtick-quoted string, so a document cannot
+ *   silently turn into a template-literal substitution if later evaluated as
+ *   JavaScript. Independent of `esStrictCompatible`. Defaults to `false`.
+ * @property {boolean} [warnWithCommentWithoutEOL] When `true`, a `//` comment
+ *   that reaches the end of the document with no terminating line break logs
+ *   a console warning. The input is accepted either way. Defaults to `false`.
  */
 
 /**
@@ -182,8 +210,17 @@ JSON6.escape = function(string) {
 /**
  * @param {(value: unknown) => void} [cb]
  * @param {Json6Reviver|undefined} [reviver]
+ * @param {Json6ParseOptions} [options]
  */
-JSON6.begin = function( cb, reviver ) {
+JSON6.begin = function( cb, reviver, options ) {
+
+	const beginOptions = options;
+	/** @type {boolean} */
+	let esStrictCompatible = !!( beginOptions && beginOptions.esStrictCompatible );
+	/** @type {boolean} */
+	let forbidTemplateSubstitution = !!( beginOptions && beginOptions.forbidTemplateSubstitution );
+	/** @type {boolean} */
+	let warnWithCommentWithoutEOL = !!( beginOptions && beginOptions.warnWithCommentWithoutEOL );
 
 	const val = /** @type {{ name: string|null, value_type: number, string: string, contains: unknown }} */ ({ name : null,   // name of this value (if it's contained in an object)
 		value_type: VALUE_UNSET, // value from above indiciating the type of this value
@@ -216,7 +253,8 @@ JSON6.begin = function( cb, reviver ) {
 		stringHex = false,
 		hex_char = 0,
 		hex_char_len = 0,
-		completed = false;
+		completed = false,
+		dollarSeen = false;
 
 	const context_stack = /** @type {{
 		first: NodeInfo<Context>|null,
@@ -315,7 +353,8 @@ JSON6.begin = function( cb, reviver ) {
 				case 1:
 					return throwEndError( "Comment began at end of document" );
 				case 2:
-					console.log( "Warning: '//' comment without end of line ended document" );
+					if( warnWithCommentWithoutEOL )
+						console.log( "Warning: '//' comment without end of line ended document" );
 					break;
 				case 3:
 					return throwEndError( "Open comment '/*' is missing close at end of document" );
@@ -331,7 +370,16 @@ JSON6.begin = function( cb, reviver ) {
 			result = undefined;
 			return r;
 		},
-		reset() {
+		/**
+		 * @param {Json6ParseOptions} [resetOptions] Options for the next parse.
+		 *   When omitted, the options passed to `begin()` (if any) stay in
+		 *   effect.
+		 */
+		reset( resetOptions ) {
+			const activeOptions = resetOptions === undefined ? beginOptions : resetOptions;
+			esStrictCompatible = !!( activeOptions && activeOptions.esStrictCompatible );
+			forbidTemplateSubstitution = !!( activeOptions && activeOptions.forbidTemplateSubstitution );
+			warnWithCommentWithoutEOL = !!( activeOptions && activeOptions.warnWithCommentWithoutEOL );
 			word = WORD_POS_RESET;
 			status = true;
 			if( inQueue.last ) inQueue.last.next = inQueue.save;
@@ -352,6 +400,8 @@ JSON6.begin = function( cb, reviver ) {
 			signSeen = false;
 			comment = 0;
 			completed = false;
+			signSeen = false;
+			dollarSeen = false;
 			gatheringStringFirstChar = null;
 			gatheringString = false;
 			stringEscape = false;  // string stringEscape intro
@@ -569,6 +619,11 @@ JSON6.begin = function( cb, reviver ) {
 			 */
 			function gatherString( start_c ) {
 				let retval = 0;
+				// Hoisted out of the per-character loop: these are constant for
+				// the whole string, so the default (non-strict) path adds no
+				// work beyond one predictable branch.
+				const strictQuote = esStrictCompatible && start_c !== 96/*'`'*/;
+				const trackTemplate = start_c === 96/*'`'*/ && forbidTemplateSubstitution;
 				while( retval == 0 && ( n < buf.length ) ) {
 					let str = buf.charAt(n);
 					const cInt = ensureDefined( buf.codePointAt(n++), "Unexpected end of string" );
@@ -667,6 +722,8 @@ JSON6.begin = function( cb, reviver ) {
 							val.string += '\b';
 							break;
 						case 48/*'0'*/:
+							if( esStrictCompatible && buf.charCodeAt( n ) >= 48/*'0'*/ && buf.charCodeAt( n ) <= 57/*'9'*/ )
+								throwError( "Legacy octal string escapes are not allowed when the 'esStrictCompatible' option is set", buf.charCodeAt( n ) );
 							val.string += '\0';
 							break;
 						case 110/*'n'*/:
@@ -692,6 +749,8 @@ JSON6.begin = function( cb, reviver ) {
 							hex_char = 0;
 							continue;
 						default:
+							if( esStrictCompatible && cInt >= 49/*'1'*/ && cInt <= 57/*'9'*/ )
+								throwError( "Legacy octal string escapes are not allowed when the 'esStrictCompatible' option is set", cInt );
 							val.string += str;
 							break;
 						}
@@ -700,8 +759,17 @@ JSON6.begin = function( cb, reviver ) {
 					}
 					else if( cInt === 92/*'\\'*/ ) {
 						stringEscape = true;
+						dollarSeen = false;
 					}
 					else {
+						if( strictQuote
+							&& ( cInt === 10/*'\n'*/ || cInt === 13/*'\r'*/ || cInt === 0x2028 || cInt === 0x2029 ) )
+							throwError( "Literal line terminators inside single- or double-quoted strings require the 'esStrictCompatible' option to be off", cInt );
+						if( trackTemplate ) {
+							if( dollarSeen && cInt === 123/*'{'*/ )
+								throwError( "Template substitution ${ } is not allowed when the 'forbidTemplateSubstitution' option is set", cInt );
+							dollarSeen = cInt === 36/*'$'*/;
+						}
 						if( cr_escaped ) {
 							cr_escaped = false;
 							// \\ \r <any other character>
@@ -729,6 +797,8 @@ JSON6.begin = function( cb, reviver ) {
 					pos.col++;
 					// leading zeros should be forbidden.
 					if( cInt >= 48/*'0'*/ && cInt <= 57/*'9'*/ ) {
+						if( esStrictCompatible && val.string === '0' )
+							throwError( "Legacy octal / leading-zero numbers are not allowed when the 'esStrictCompatible' option is set", cInt );
 						if( exponent ) {
 							exponent_digit = true;
 						}
@@ -946,6 +1016,10 @@ JSON6.begin = function( cb, reviver ) {
 						////log('_DEBUG_PARSING', "colon context:", parse_context );
 						if( parse_context == CONTEXT_OBJECT_FIELD ) {
 							word = WORD_POS_RESET;
+							if( esStrictCompatible && val.value_type !== VALUE_STRING
+								&& !ES_IDENTIFIER_NAME.test( val.string )
+								&& Number.isNaN( Number( val.string ) ) )
+								throwError( "Unquoted keys must be valid identifiers when the 'esStrictCompatible' option is set", cInt );
 							val.name = val.string;
 							val.string = '';
 							parse_context = CONTEXT_OBJECT_FIELD_VALUE;
@@ -1013,6 +1087,7 @@ JSON6.begin = function( cb, reviver ) {
 							throwError( "Fault while parsing; unexpected", cInt );
 						}
 						negative = false;
+						signSeen = false;
 						break;
 					case 93/*']'*/:
 						if( word == WORD_POS_END ) word = WORD_POS_RESET;
@@ -1041,6 +1116,7 @@ JSON6.begin = function( cb, reviver ) {
 							throwError( `bad context ${parse_context}; fault while parsing`, cInt );// fault
 						}
 						negative = false;
+						signSeen = false;
 						break;
 					case 44/*','*/:
 						if( word == WORD_POS_END ) word = WORD_POS_RESET;  // allow collect new keyword
@@ -1070,12 +1146,16 @@ JSON6.begin = function( cb, reviver ) {
 							throwError( "bad context; excessive commas while parsing;", cInt );// fault
 						}
 						negative = false;
+						signSeen = false;
 						break;
 
 					default:
 						if( parse_context == CONTEXT_OBJECT_FIELD ) {
 							switch( cInt ) {
 							case 96://'`':
+								if( esStrictCompatible )
+									throwError( "Backtick-quoted keys are not allowed when the 'esStrictCompatible' option is set", cInt );
+								// falls through
 							case 34://'"':
 							case 39://'\'':
 								if( word == WORD_POS_RESET ) {
@@ -1157,6 +1237,7 @@ JSON6.begin = function( cb, reviver ) {
 						case 0xFEFF://'\uFEFF':
 							if( word == WORD_POS_END ) {
 								word = WORD_POS_RESET;
+								signSeen = false;
 								if( parse_context == CONTEXT_UNKNOWN ) {
 									completed = true;
 								}
@@ -1251,12 +1332,23 @@ JSON6.begin = function( cb, reviver ) {
 							else { status = false; throwError( "fault parsing", cInt ); }// fault
 							break;
 						case 45://'-':
-							if( word == WORD_POS_RESET ) { checkValueSeparator( cInt ); signSeen = true; negative = !negative; }
+							if( word == WORD_POS_RESET ) {
+								checkValueSeparator( cInt );
+								if( esStrictCompatible && signSeen )
+									throwError( "Multiple consecutive signs are not allowed when the 'esStrictCompatible' option is set", cInt );
+								signSeen = true;
+								negative = !negative;
+							}
 							else { status = false; throwError( "fault parsing", cInt ); }// fault
 							break;
 						case 43://'+':
 							if( word !== WORD_POS_RESET ) { status = false; throwError( "fault parsing", cInt ); }// fault
-							else { checkValueSeparator( cInt ); signSeen = true; }
+							else {
+								checkValueSeparator( cInt );
+								if( esStrictCompatible && signSeen )
+									throwError( "Multiple consecutive signs are not allowed when the 'esStrictCompatible' option is set", cInt );
+								signSeen = true;
+							}
 							break;
 							//
 							//----------------------------------------------------------
@@ -1268,6 +1360,7 @@ JSON6.begin = function( cb, reviver ) {
 								exponent_sign = false;
 								exponent_digit = false;
 								decimal = false;
+								signSeen = false;
 								val.string = str;
 								input.n = n;
 								collectNumber();
@@ -1368,15 +1461,16 @@ let _parse_level = 0;
 /**
  * @param {unknown} msg
  * @param {Json6Reviver} [reviver]
+ * @param {Json6ParseOptions} [options]
  */
-JSON6.parse = function( msg, reviver ) {
+JSON6.parse = function( msg, reviver, options ) {
 	//var parser = JSON6.begin();
 	const parse_level = _parse_level++;
 	if( _parser.length <= parse_level )
 		_parser.push( Object.freeze( JSON6.begin() ) );
 	const parser = _parser[parse_level];
 	if (typeof msg !== "string") msg = String(msg);
-	parser.reset();
+	parser.reset( options );
 	try {
 		if( parser._write( /** @type {string} */ (msg), true ) <= 0 ) {
 			// nothing completed: empty document, whitespace, or only comments.

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
         "typescript": "latest"
     },
     "nyc": {
+        "check-coverage": true,
         "statements": 100,
         "branches": 100,
         "functions": 100,

--- a/package.json6
+++ b/package.json6
@@ -76,6 +76,7 @@
         typescript: 'latest'
     },
     nyc: {
+        check-coverage: true,
         statements: 100,
         branches: 100,
         functions: 100,

--- a/src/json6.js
+++ b/src/json6.js
@@ -1517,6 +1517,7 @@ JSON6.parse = function( msg, reviver, options ) {
  * @property {(o?: unknown, r?: Json6Replacer, s?: string|number|null, as?: string) => string|undefined} stringify
  * @property {(q: string) => void} setQuote
  * @property {boolean} ignoreNonEnumerable
+ * @property {boolean} sortKeys
  */
 
 /** @type {Json6Stringifier|null} */
@@ -1526,6 +1527,9 @@ JSON6.stringifier = function() {
 	let useQuote = '"';
 
 	let ignoreNonEnumerable = false;
+	// preserves the historical (sorted) output by default; set to `false` to
+	// emit keys in their own enumeration order instead.
+	let sortKeys = true;
 
 	return {
 		/**
@@ -1542,6 +1546,8 @@ JSON6.stringifier = function() {
 		setQuote(q) { useQuote = q; },
 		get ignoreNonEnumerable() { return ignoreNonEnumerable; },
 		set ignoreNonEnumerable(val) { ignoreNonEnumerable = val; },
+		get sortKeys() { return sortKeys; },
+		set sortKeys(val) { sortKeys = val; },
 	};
 
 	/**
@@ -1729,16 +1735,20 @@ JSON6.stringifier = function() {
 								continue;
 							}
 
-						// sort properties into keys.
 						if (Object.prototype.hasOwnProperty.call(record, k)) {
-							let n;
-							for( n = 0; n < keys.length; n++ )
-								if( keys[n] > k ) {
-									keys.splice(n,0,k );
-									break;
-								}
-							if( n === keys.length )
+							if( sortKeys ) {
+								// sort properties into keys.
+								let n;
+								for( n = 0; n < keys.length; n++ )
+									if( keys[n] > k ) {
+										keys.splice(n,0,k );
+										break;
+									}
+								if( n === keys.length )
+									keys.push(k);
+							} else {
 								keys.push(k);
+							}
 						}
 					}
 					//_DEBUG_STRINGIFY && console.log( "Expanding object keys:", v, keys );
@@ -1777,13 +1787,21 @@ JSON6.stringifier = function() {
 };
 
 /**
+ * @typedef {object} Json6StringifyOptions
+ * @property {boolean} [sortKeys] When `false`, object keys are emitted in their
+ *   own enumeration order instead of sorted. Defaults to `true`.
+ */
+
+/**
  * @param {unknown} object
  * @param {Json6Replacer} [replacer]
  * @param {string|number} [space]
+ * @param {Json6StringifyOptions} [options]
  * @returns {string|undefined}
  */
-JSON6.stringify = function( object, replacer, space ) {
+JSON6.stringify = function( object, replacer, space, options ) {
 	const stringifier = JSON6.stringifier();
+	if( options && options.sortKeys === false ) stringifier.sortKeys = false;
 	return stringifier.stringify( object, replacer, space );
 };
 

--- a/src/json6.js
+++ b/src/json6.js
@@ -66,6 +66,11 @@ const CONTEXT_OBJECT_FIELD_VALUE = 4;
 // not accept.
 const ES_IDENTIFIER_NAME = /^[$_\p{ID_Start}][$_\p{ID_Continue}]*$/u;
 
+// Matches a NumericLiteralSeparator ('_') only where it is legal: between two
+// digits. Used only by `esStrictCompatible` to recognize unquoted numeric keys
+// like `1_000` as valid JS -- `Number()` itself rejects the underscore.
+const NUMERIC_SEPARATOR = /(\d)_(?=\d)/g;
+
 /**
  * @typedef {{
  *   n: number,
@@ -1017,7 +1022,7 @@ JSON6.begin = function( cb, reviver, options ) {
 							word = WORD_POS_RESET;
 							if( esStrictCompatible && val.value_type !== VALUE_STRING
 								&& !ES_IDENTIFIER_NAME.test( val.string )
-								&& Number.isNaN( Number( val.string ) ) )
+								&& Number.isNaN( Number( val.string.replace( NUMERIC_SEPARATOR, '$1' ) ) ) )
 								throwError( "Unquoted keys must be valid identifiers when the 'esStrictCompatible' option is set", cInt );
 							val.name = val.string;
 							val.string = '';

--- a/src/json6.js
+++ b/src/json6.js
@@ -60,11 +60,39 @@ const CONTEXT_IN_ARRAY = 1;
 const CONTEXT_OBJECT_FIELD = 3;
 const CONTEXT_OBJECT_FIELD_VALUE = 4;
 
+// Matches an ECMAScript `IdentifierName` (the production that may appear
+// unquoted as an object-literal property key in JavaScript). Used only by the
+// opt-in `esStrictCompatible` mode to reject unquoted keys JavaScript would
+// not accept.
+const ES_IDENTIFIER_NAME = /^[$_\p{ID_Start}][$_\p{ID_Continue}]*$/u;
+
 /**
  * @typedef {{
  *   n: number,
  *   buf: null|string
  * }} Json6Node
+ */
+
+/**
+ * Options accepted by {@link JSON6.parse} and {@link JSON6.begin}. All are
+ * off by default: with no options JSON6 accepts its full historical grammar.
+ *
+ * @typedef {object} Json6ParseOptions
+ * @property {boolean} [esStrictCompatible] When `true`, reject the JSON6
+ *   extensions that are not valid in ECMAScript strict mode, so accepted
+ *   input can be pasted into a module or `eval`'d unchanged: legacy-octal /
+ *   leading-zero numbers (`0123`); legacy octal string escapes (`"\012"`,
+ *   `"\1"`..`"\9"`); literal line terminators inside `'`/`"` strings
+ *   (backtick strings still allow them); backtick-quoted object keys;
+ *   unquoted object keys that are neither identifiers nor numbers; and two or
+ *   more consecutive unary `+`/`-` signs. Defaults to `false`.
+ * @property {boolean} [forbidTemplateSubstitution] When `true`, reject an
+ *   unescaped `${` inside a backtick-quoted string, so a document cannot
+ *   silently turn into a template-literal substitution if later evaluated as
+ *   JavaScript. Independent of `esStrictCompatible`. Defaults to `false`.
+ * @property {boolean} [warnWithCommentWithoutEOL] When `true`, a `//` comment
+ *   that reaches the end of the document with no terminating line break logs
+ *   a console warning. The input is accepted either way. Defaults to `false`.
  */
 
 /**
@@ -180,8 +208,17 @@ JSON6.escape = function(string) {
 /**
  * @param {(value: unknown) => void} [cb]
  * @param {Json6Reviver|undefined} [reviver]
+ * @param {Json6ParseOptions} [options]
  */
-JSON6.begin = function( cb, reviver ) {
+JSON6.begin = function( cb, reviver, options ) {
+
+	const beginOptions = options;
+	/** @type {boolean} */
+	let esStrictCompatible = !!( beginOptions && beginOptions.esStrictCompatible );
+	/** @type {boolean} */
+	let forbidTemplateSubstitution = !!( beginOptions && beginOptions.forbidTemplateSubstitution );
+	/** @type {boolean} */
+	let warnWithCommentWithoutEOL = !!( beginOptions && beginOptions.warnWithCommentWithoutEOL );
 
 	const val = /** @type {{ name: string|null, value_type: number, string: string, contains: unknown }} */ ({ name : null,   // name of this value (if it's contained in an object)
 		value_type: VALUE_UNSET, // value from above indiciating the type of this value
@@ -214,7 +251,8 @@ JSON6.begin = function( cb, reviver ) {
 		stringHex = false,
 		hex_char = 0,
 		hex_char_len = 0,
-		completed = false;
+		completed = false,
+		dollarSeen = false;
 
 	const context_stack = /** @type {{
 		first: NodeInfo<Context>|null,
@@ -313,7 +351,8 @@ JSON6.begin = function( cb, reviver ) {
 				case 1:
 					return throwEndError( "Comment began at end of document" );
 				case 2:
-					console.log( "Warning: '//' comment without end of line ended document" );
+					if( warnWithCommentWithoutEOL )
+						console.log( "Warning: '//' comment without end of line ended document" );
 					break;
 				case 3:
 					return throwEndError( "Open comment '/*' is missing close at end of document" );
@@ -329,7 +368,16 @@ JSON6.begin = function( cb, reviver ) {
 			result = undefined;
 			return r;
 		},
-		reset() {
+		/**
+		 * @param {Json6ParseOptions} [resetOptions] Options for the next parse.
+		 *   When omitted, the options passed to `begin()` (if any) stay in
+		 *   effect.
+		 */
+		reset( resetOptions ) {
+			const activeOptions = resetOptions === undefined ? beginOptions : resetOptions;
+			esStrictCompatible = !!( activeOptions && activeOptions.esStrictCompatible );
+			forbidTemplateSubstitution = !!( activeOptions && activeOptions.forbidTemplateSubstitution );
+			warnWithCommentWithoutEOL = !!( activeOptions && activeOptions.warnWithCommentWithoutEOL );
 			word = WORD_POS_RESET;
 			status = true;
 			if( inQueue.last ) inQueue.last.next = inQueue.save;
@@ -350,6 +398,8 @@ JSON6.begin = function( cb, reviver ) {
 			signSeen = false;
 			comment = 0;
 			completed = false;
+			signSeen = false;
+			dollarSeen = false;
 			gatheringStringFirstChar = null;
 			gatheringString = false;
 			stringEscape = false;  // string stringEscape intro
@@ -567,6 +617,11 @@ JSON6.begin = function( cb, reviver ) {
 			 */
 			function gatherString( start_c ) {
 				let retval = 0;
+				// Hoisted out of the per-character loop: these are constant for
+				// the whole string, so the default (non-strict) path adds no
+				// work beyond one predictable branch.
+				const strictQuote = esStrictCompatible && start_c !== 96/*'`'*/;
+				const trackTemplate = start_c === 96/*'`'*/ && forbidTemplateSubstitution;
 				while( retval == 0 && ( n < buf.length ) ) {
 					let str = buf.charAt(n);
 					const cInt = ensureDefined( buf.codePointAt(n++), "Unexpected end of string" );
@@ -665,6 +720,8 @@ JSON6.begin = function( cb, reviver ) {
 							val.string += '\b';
 							break;
 						case 48/*'0'*/:
+							if( esStrictCompatible && buf.charCodeAt( n ) >= 48/*'0'*/ && buf.charCodeAt( n ) <= 57/*'9'*/ )
+								throwError( "Legacy octal string escapes are not allowed when the 'esStrictCompatible' option is set", buf.charCodeAt( n ) );
 							val.string += '\0';
 							break;
 						case 110/*'n'*/:
@@ -690,6 +747,8 @@ JSON6.begin = function( cb, reviver ) {
 							hex_char = 0;
 							continue;
 						default:
+							if( esStrictCompatible && cInt >= 49/*'1'*/ && cInt <= 57/*'9'*/ )
+								throwError( "Legacy octal string escapes are not allowed when the 'esStrictCompatible' option is set", cInt );
 							val.string += str;
 							break;
 						}
@@ -698,8 +757,17 @@ JSON6.begin = function( cb, reviver ) {
 					}
 					else if( cInt === 92/*'\\'*/ ) {
 						stringEscape = true;
+						dollarSeen = false;
 					}
 					else {
+						if( strictQuote
+							&& ( cInt === 10/*'\n'*/ || cInt === 13/*'\r'*/ || cInt === 0x2028 || cInt === 0x2029 ) )
+							throwError( "Literal line terminators inside single- or double-quoted strings require the 'esStrictCompatible' option to be off", cInt );
+						if( trackTemplate ) {
+							if( dollarSeen && cInt === 123/*'{'*/ )
+								throwError( "Template substitution ${ } is not allowed when the 'forbidTemplateSubstitution' option is set", cInt );
+							dollarSeen = cInt === 36/*'$'*/;
+						}
 						if( cr_escaped ) {
 							cr_escaped = false;
 							// \\ \r <any other character>
@@ -727,6 +795,8 @@ JSON6.begin = function( cb, reviver ) {
 					pos.col++;
 					// leading zeros should be forbidden.
 					if( cInt >= 48/*'0'*/ && cInt <= 57/*'9'*/ ) {
+						if( esStrictCompatible && val.string === '0' )
+							throwError( "Legacy octal / leading-zero numbers are not allowed when the 'esStrictCompatible' option is set", cInt );
 						if( exponent ) {
 							exponent_digit = true;
 						}
@@ -944,6 +1014,10 @@ JSON6.begin = function( cb, reviver ) {
 						////log('_DEBUG_PARSING', "colon context:", parse_context );
 						if( parse_context == CONTEXT_OBJECT_FIELD ) {
 							word = WORD_POS_RESET;
+							if( esStrictCompatible && val.value_type !== VALUE_STRING
+								&& !ES_IDENTIFIER_NAME.test( val.string )
+								&& Number.isNaN( Number( val.string ) ) )
+								throwError( "Unquoted keys must be valid identifiers when the 'esStrictCompatible' option is set", cInt );
 							val.name = val.string;
 							val.string = '';
 							parse_context = CONTEXT_OBJECT_FIELD_VALUE;
@@ -1011,6 +1085,7 @@ JSON6.begin = function( cb, reviver ) {
 							throwError( "Fault while parsing; unexpected", cInt );
 						}
 						negative = false;
+						signSeen = false;
 						break;
 					case 93/*']'*/:
 						if( word == WORD_POS_END ) word = WORD_POS_RESET;
@@ -1039,6 +1114,7 @@ JSON6.begin = function( cb, reviver ) {
 							throwError( `bad context ${parse_context}; fault while parsing`, cInt );// fault
 						}
 						negative = false;
+						signSeen = false;
 						break;
 					case 44/*','*/:
 						if( word == WORD_POS_END ) word = WORD_POS_RESET;  // allow collect new keyword
@@ -1068,12 +1144,16 @@ JSON6.begin = function( cb, reviver ) {
 							throwError( "bad context; excessive commas while parsing;", cInt );// fault
 						}
 						negative = false;
+						signSeen = false;
 						break;
 
 					default:
 						if( parse_context == CONTEXT_OBJECT_FIELD ) {
 							switch( cInt ) {
 							case 96://'`':
+								if( esStrictCompatible )
+									throwError( "Backtick-quoted keys are not allowed when the 'esStrictCompatible' option is set", cInt );
+								// falls through
 							case 34://'"':
 							case 39://'\'':
 								if( word == WORD_POS_RESET ) {
@@ -1155,6 +1235,7 @@ JSON6.begin = function( cb, reviver ) {
 						case 0xFEFF://'\uFEFF':
 							if( word == WORD_POS_END ) {
 								word = WORD_POS_RESET;
+								signSeen = false;
 								if( parse_context == CONTEXT_UNKNOWN ) {
 									completed = true;
 								}
@@ -1249,12 +1330,23 @@ JSON6.begin = function( cb, reviver ) {
 							else { status = false; throwError( "fault parsing", cInt ); }// fault
 							break;
 						case 45://'-':
-							if( word == WORD_POS_RESET ) { checkValueSeparator( cInt ); signSeen = true; negative = !negative; }
+							if( word == WORD_POS_RESET ) {
+								checkValueSeparator( cInt );
+								if( esStrictCompatible && signSeen )
+									throwError( "Multiple consecutive signs are not allowed when the 'esStrictCompatible' option is set", cInt );
+								signSeen = true;
+								negative = !negative;
+							}
 							else { status = false; throwError( "fault parsing", cInt ); }// fault
 							break;
 						case 43://'+':
 							if( word !== WORD_POS_RESET ) { status = false; throwError( "fault parsing", cInt ); }// fault
-							else { checkValueSeparator( cInt ); signSeen = true; }
+							else {
+								checkValueSeparator( cInt );
+								if( esStrictCompatible && signSeen )
+									throwError( "Multiple consecutive signs are not allowed when the 'esStrictCompatible' option is set", cInt );
+								signSeen = true;
+							}
 							break;
 							//
 							//----------------------------------------------------------
@@ -1266,6 +1358,7 @@ JSON6.begin = function( cb, reviver ) {
 								exponent_sign = false;
 								exponent_digit = false;
 								decimal = false;
+								signSeen = false;
 								val.string = str;
 								input.n = n;
 								collectNumber();
@@ -1366,15 +1459,16 @@ let _parse_level = 0;
 /**
  * @param {unknown} msg
  * @param {Json6Reviver} [reviver]
+ * @param {Json6ParseOptions} [options]
  */
-JSON6.parse = function( msg, reviver ) {
+JSON6.parse = function( msg, reviver, options ) {
 	//var parser = JSON6.begin();
 	const parse_level = _parse_level++;
 	if( _parser.length <= parse_level )
 		_parser.push( Object.freeze( JSON6.begin() ) );
 	const parser = _parser[parse_level];
 	if (typeof msg !== "string") msg = String(msg);
-	parser.reset();
+	parser.reset( options );
 	try {
 		if( parser._write( /** @type {string} */ (msg), true ) <= 0 ) {
 			// nothing completed: empty document, whitespace, or only comments.

--- a/src/json6.js
+++ b/src/json6.js
@@ -760,8 +760,9 @@ JSON6.begin = function( cb, reviver, options ) {
 						dollarSeen = false;
 					}
 					else {
-						if( strictQuote
-							&& ( cInt === 10/*'\n'*/ || cInt === 13/*'\r'*/ || cInt === 0x2028 || cInt === 0x2029 ) )
+						// U+2028/U+2029 are legal, unescaped, inside string literals since
+						// ES2019 (the JSON-superset proposal); only \n and \r are illegal.
+						if( strictQuote && ( cInt === 10/*'\n'*/ || cInt === 13/*'\r'*/ ) )
 							throwError( "Literal line terminators inside single- or double-quoted strings require the 'esStrictCompatible' option to be off", cInt );
 						if( trackTemplate ) {
 							if( dollarSeen && cInt === 123/*'{'*/ )

--- a/test/1.0.9-stringify.js
+++ b/test/1.0.9-stringify.js
@@ -80,6 +80,26 @@ describe('JSON6 stringify', function () {
 		expect( stringifier.stringify( { a:'x y' } ) ).to.equal( "{a:'x y'}" );
 	} );
 
+	it('sorts keys by default', function () {
+		const stringifier = JSON6.stringifier();
+		expect( stringifier.sortKeys ).to.equal( true );
+	} );
+
+	it('can disable key sorting via the stringifier', function () {
+		const stringifier = JSON6.stringifier();
+		stringifier.sortKeys = false;
+		expect( stringifier.stringify( { z:1, a:2, m:3 } ) ).to.equal( '{z:1,a:2,m:3}' );
+	} );
+
+	it('can disable key sorting via JSON6.stringify options', function () {
+		expect( JSON6.stringify( { z:1, a:2, m:3 }, undefined, undefined, { sortKeys:false } ) )
+			.to.equal( '{z:1,a:2,m:3}' );
+	} );
+
+	it('still sorts keys when sortKeys option is not passed', function () {
+		expect( JSON6.stringify( { z:1, a:2, m:3 } ) ).to.equal( '{a:2,m:3,z:1}' );
+	} );
+
 	it('indents using a numeric space argument', function () {
 		expect( JSON6.stringify( { a:1 }, null, 2 ) ).to.equal( '{\n  a: 1\n}' );
 	} );

--- a/test/esStrictCompatible.js
+++ b/test/esStrictCompatible.js
@@ -1,0 +1,245 @@
+'use strict';
+const { expect } = require( 'chai' );
+const JSON6 = require( '..' );
+
+const parse = JSON6.parse;
+const STRICT = { esStrictCompatible: true };
+
+describe('esStrictCompatible option', function () {
+	describe('Legacy-octal / leading-zero numbers', function () {
+		it('accepts a leading-zero number by default (decimal)', function () {
+			expect( parse( '0123' ) ).to.equal( 123 );
+			expect( parse( '[-0123]' ) ).to.deep.equal( [ -123 ] );
+			expect( parse( '{a: 0123}' ) ).to.deep.equal( { a: 123 } );
+		});
+		it('rejects a leading-zero number when esStrictCompatible', function () {
+			expect(function () {
+				parse( '0123', undefined, STRICT );
+			}).to.throw( Error, /leading-zero numbers are not allowed/ );
+		});
+		it('rejects `00` when esStrictCompatible', function () {
+			expect(function () {
+				parse( '00', undefined, STRICT );
+			}).to.throw( Error, /leading-zero numbers are not allowed/ );
+		});
+		it('still accepts a bare zero, decimal, and radix prefixes when esStrictCompatible', function () {
+			expect( parse( '0', undefined, STRICT ) ).to.equal( 0 );
+			expect( parse( '0.5', undefined, STRICT ) ).to.equal( 0.5 );
+			expect( parse( '0e1', undefined, STRICT ) ).to.equal( 0 );
+			expect( parse( '0x1F', undefined, STRICT ) ).to.equal( 31 );
+		});
+	});
+
+	describe('Legacy octal string escapes', function () {
+		it('strips them by default', function () {
+			expect( parse( '"\\056"' ) ).to.equal( '\0' + '56' );
+			expect( parse( '"\\1"' ) ).to.equal( '1' );
+		});
+		it('rejects `\\0` followed by a digit when esStrictCompatible', function () {
+			expect(function () {
+				parse( '"\\056"', undefined, STRICT );
+			}).to.throw( Error, /Legacy octal string escapes/ );
+		});
+		it('rejects `\\1` through `\\9` when esStrictCompatible', function () {
+			expect(function () {
+				parse( '"\\1"', undefined, STRICT );
+			}).to.throw( Error, /Legacy octal string escapes/ );
+			expect(function () {
+				parse( '"\\9"', undefined, STRICT );
+			}).to.throw( Error, /Legacy octal string escapes/ );
+		});
+		it('still accepts a lone `\\0` (NUL) and unknown escapes when esStrictCompatible', function () {
+			expect( parse( '"\\0"', undefined, STRICT ) ).to.equal( '\0' );
+			expect( parse( '"\\0A"', undefined, STRICT ) ).to.equal( '\0A' );
+			expect( parse( '"\\!"', undefined, STRICT ) ).to.equal( '!' );
+		});
+	});
+
+	describe('Literal line terminators inside single- or double-quoted strings', function () {
+		it('keeps them by default', function () {
+			expect( parse( "{a:'abc\ndef'}" ) ).to.deep.equal( { a: 'abc\ndef' } );
+		});
+		it('rejects a literal LF / CR when esStrictCompatible', function () {
+			expect(function () {
+				parse( '"a\nb"', undefined, STRICT );
+			}).to.throw( Error, /Literal line terminators/ );
+			expect(function () {
+				parse( "'a\rb'", undefined, STRICT );
+			}).to.throw( Error, /Literal line terminators/ );
+		});
+		it('rejects a literal line/paragraph separator when esStrictCompatible', function () {
+			expect(function () {
+				parse( '"a' + String.fromCharCode( 0x2028 ) + 'b"', undefined, STRICT );
+			}).to.throw( Error, /Literal line terminators/ );
+			expect(function () {
+				parse( '"a' + String.fromCharCode( 0x2029 ) + 'b"', undefined, STRICT );
+			}).to.throw( Error, /Literal line terminators/ );
+		});
+		it('still allows literal newlines inside a backtick string when esStrictCompatible', function () {
+			expect( parse( '`a\nb`', undefined, STRICT ) ).to.equal( 'a\nb' );
+		});
+	});
+
+	describe('Backtick-quoted object keys', function () {
+		it('accepts a backtick key by default', function () {
+			expect( parse( '{`a`:123}' ) ).to.deep.equal( { a: 123 } );
+		});
+		it('rejects a backtick key when esStrictCompatible', function () {
+			expect(function () {
+				parse( '{`a`:123}', undefined, STRICT );
+			}).to.throw( Error, /Backtick-quoted keys are not allowed/ );
+		});
+		it('still allows a backtick-quoted value when esStrictCompatible', function () {
+			expect( parse( '{a:`b`}', undefined, STRICT ) ).to.deep.equal( { a: 'b' } );
+		});
+	});
+
+	describe('Unquoted keys that are not valid identifiers', function () {
+		it('accepts a hyphenated key by default', function () {
+			expect( parse( '{a-b:1}' ) ).to.deep.equal( { 'a-b': 1 } );
+		});
+		it('rejects a hyphenated key when esStrictCompatible', function () {
+			expect(function () {
+				parse( '{a-b:1}', undefined, STRICT );
+			}).to.throw( Error, /Unquoted keys must be valid identifiers/ );
+		});
+		it('rejects a key that starts with a digit when esStrictCompatible', function () {
+			expect(function () {
+				parse( '{1x:1}', undefined, STRICT );
+			}).to.throw( Error, /Unquoted keys must be valid identifiers/ );
+		});
+		it('still accepts identifier, numeric, and quoted keys when esStrictCompatible', function () {
+			expect( parse( '{ _a$B0 : 1 }', undefined, STRICT ) ).to.deep.equal( { _a$B0: 1 } );
+			expect( parse( '{ 123: 1 }', undefined, STRICT ) ).to.deep.equal( { 123: 1 } );
+			expect( parse( '{ "a-b": 1 }', undefined, STRICT ) ).to.deep.equal( { 'a-b': 1 } );
+		});
+	});
+
+	describe('Multiple consecutive unary signs', function () {
+		it('accepts stacked signs by default', function () {
+			expect( parse( '--5' ) ).to.equal( 5 );
+			expect( parse( '---5' ) ).to.equal( -5 );
+		});
+		it('rejects `--5`, `+-5`, `++5` when esStrictCompatible', function () {
+			expect(function () {
+				parse( '--5', undefined, STRICT );
+			}).to.throw( Error, /Multiple consecutive signs/ );
+			expect(function () {
+				parse( '+-5', undefined, STRICT );
+			}).to.throw( Error, /Multiple consecutive signs/ );
+			expect(function () {
+				parse( '++5', undefined, STRICT );
+			}).to.throw( Error, /Multiple consecutive signs/ );
+		});
+		it('rejects signs separated only by whitespace when esStrictCompatible', function () {
+			expect(function () {
+				parse( '- - 5', undefined, STRICT );
+			}).to.throw( Error, /Multiple consecutive signs/ );
+		});
+		it('still accepts a single leading sign when esStrictCompatible', function () {
+			expect( parse( '-5', undefined, STRICT ) ).to.equal( -5 );
+			expect( parse( '+5', undefined, STRICT ) ).to.equal( 5 );
+			expect( parse( '-   5', undefined, STRICT ) ).to.equal( -5 );
+			expect( parse( '-Infinity', undefined, STRICT ) ).to.equal( -Infinity );
+			expect( parse( '-NaN', undefined, STRICT ) ).to.be.NaN;
+		});
+		it('clears the sign guard between successive values (esStrictCompatible)', function () {
+			expect( parse( '[-1,-2]', undefined, STRICT ) ).to.deep.equal( [ -1, -2 ] );
+			expect( parse( '{a:-1,b:-2}', undefined, STRICT ) ).to.deep.equal( { a: -1, b: -2 } );
+			expect( parse( '[[-1],-2]', undefined, STRICT ) ).to.deep.equal( [ [ -1 ], -2 ] );
+			expect( parse( '[-Infinity, -Infinity]', undefined, STRICT ) ).to.deep.equal( [ -Infinity, -Infinity ] );
+		});
+		it('clears the sign guard between streamed top-level values (esStrictCompatible)', function () {
+			/** @type {unknown[]} */
+			const results = [];
+			const parser = JSON6.begin( function ( v ) {
+				results.push( v );
+			}, undefined, STRICT );
+			parser.write( '-1 ' );
+			parser.write( '-2 ' );
+			expect( results ).to.deep.equal( [ -1, -2 ] );
+		});
+	});
+
+	describe('forbidTemplateSubstitution option', function () {
+		it('takes `${` as literal text by default', function () {
+			expect( parse( '`a${b}`' ) ).to.equal( 'a${b}' );
+			expect( parse( '`a${b}`', undefined, STRICT ) ).to.equal( 'a${b}' );
+		});
+		it('rejects an unescaped `${` in a backtick string when set', function () {
+			expect(function () {
+				parse( '`a${b}`', undefined, { forbidTemplateSubstitution: true } );
+			}).to.throw( Error, /Template substitution/ );
+		});
+		it('is independent of esStrictCompatible', function () {
+			expect(function () {
+				parse( '`a${b}`', undefined, { esStrictCompatible: true, forbidTemplateSubstitution: true } );
+			}).to.throw( Error, /Template substitution/ );
+		});
+		it('does not flag `$` not followed by `{`, or `{` not preceded by `$`', function () {
+			const opts = { forbidTemplateSubstitution: true };
+			expect( parse( '`a$b`', undefined, opts ) ).to.equal( 'a$b' );
+			expect( parse( '`a$`', undefined, opts ) ).to.equal( 'a$' );
+			expect( parse( '`a{b`', undefined, opts ) ).to.equal( 'a{b' );
+		});
+		it('does not flag an escaped `\\${`', function () {
+			expect( parse( '`a\\${b}`', undefined, { forbidTemplateSubstitution: true } ) ).to.equal( 'a${b}' );
+		});
+		it('ignores `${` outside of backtick strings', function () {
+			expect( parse( '"a${b}"', undefined, { forbidTemplateSubstitution: true } ) ).to.equal( 'a${b}' );
+		});
+	});
+
+	describe('warnWithCommentWithoutEOL option', function () {
+		/**
+		 * @param {string} text
+		 * @param {{ warnWithCommentWithoutEOL?: boolean }} [opts]
+		 * @returns {unknown[][]}
+		 */
+		function captureLog( text, opts ) {
+			/** @type {unknown[][]} */
+			const logged = [];
+			const origLog = console.log;
+			console.log = function (/** @type {unknown[]} */ ...args) { logged.push(args); };
+			try {
+				// a document that is only a `//` comment has no value, so this
+				// always throws; the warning (if any) is logged before the throw.
+				expect(function () { parse( text, undefined, opts ); }).to.throw(Error, /No value found/);
+			} finally {
+				console.log = origLog;
+			}
+			return logged;
+		}
+		it('is silent by default for a `//` comment that ends the document', function () {
+			expect( captureLog( '//' ) ).to.deep.equal( [] );
+		});
+		it('warns when the option is set', function () {
+			const logged = captureLog( '//', { warnWithCommentWithoutEOL: true } );
+			expect( logged ).to.have.lengthOf( 1 );
+			expect( logged[0][0] ).to.match( /comment without end of line/ );
+		});
+	});
+
+	describe('option plumbing through begin()/reset()', function () {
+		it('honors options passed to begin() for streaming input', function () {
+			const parser = JSON6.begin( undefined, undefined, STRICT );
+			expect(function () {
+				parser._write( '0123', true );
+			}).to.throw( Error, /leading-zero numbers are not allowed/ );
+		});
+		it('keeps begin() options in effect across a bare reset()', function () {
+			const parser = JSON6.begin( undefined, undefined, STRICT );
+			parser._write( '"split' );
+			parser.reset();
+			expect(function () {
+				parser._write( '0123', true );
+			}).to.throw( Error, /leading-zero numbers are not allowed/ );
+		});
+		it('lets reset(options) override begin() options', function () {
+			const parser = JSON6.begin( undefined, undefined, STRICT );
+			parser.reset( {} );
+			expect( parser._write( '0123', true ) ).to.be.above( 0 );
+			expect( parser.value() ).to.equal( 123 );
+		});
+	});
+});

--- a/test/esStrictCompatible.js
+++ b/test/esStrictCompatible.js
@@ -112,6 +112,25 @@ describe('esStrictCompatible option', function () {
 			expect( parse( '{ 123: 1 }', undefined, STRICT ) ).to.deep.equal( { 123: 1 } );
 			expect( parse( '{ "a-b": 1 }', undefined, STRICT ) ).to.deep.equal( { 'a-b': 1 } );
 		});
+		it('accepts a numeric key with numeric separators when esStrictCompatible', function () {
+			// `1_000` is a valid JS NumericLiteral even though `Number("1_000")` is NaN;
+			// the key keeps its source text, matching how other numeric keys (e.g. `1e3`) are handled.
+			expect( parse( '{1_000:1}', undefined, STRICT ) ).to.deep.equal( { '1_000': 1 } );
+		});
+		it('still rejects a key with a trailing or doubled numeric separator when esStrictCompatible', function () {
+			expect(function () {
+				parse( '{1000_:1}', undefined, STRICT );
+			}).to.throw( Error, /Unquoted keys must be valid identifiers/ );
+			expect(function () {
+				parse( '{1__000:1}', undefined, STRICT );
+			}).to.throw( Error, /Unquoted keys must be valid identifiers/ );
+		});
+		it('accepts a leading underscore as an identifier, not a numeric separator', function () {
+			// `_345` is a valid ES IdentifierName (unlike a NumericLiteral, which
+			// cannot start with `_`), so it is already accepted via the identifier
+			// check and never reaches the numeric-separator handling.
+			expect( parse( '{_345:1}', undefined, STRICT ) ).to.deep.equal( { _345: 1 } );
+		});
 	});
 
 	describe('Multiple consecutive unary signs', function () {

--- a/test/esStrictCompatible.js
+++ b/test/esStrictCompatible.js
@@ -67,13 +67,12 @@ describe('esStrictCompatible option', function () {
 				parse( "'a\rb'", undefined, STRICT );
 			}).to.throw( Error, /Literal line terminators/ );
 		});
-		it('rejects a literal line/paragraph separator when esStrictCompatible', function () {
-			expect(function () {
-				parse( '"a' + String.fromCharCode( 0x2028 ) + 'b"', undefined, STRICT );
-			}).to.throw( Error, /Literal line terminators/ );
-			expect(function () {
-				parse( '"a' + String.fromCharCode( 0x2029 ) + 'b"', undefined, STRICT );
-			}).to.throw( Error, /Literal line terminators/ );
+		it('still allows a literal line/paragraph separator when esStrictCompatible', function () {
+			// legal, unescaped, in a string literal since ES2019 (the JSON-superset proposal)
+			expect( parse( '"a' + String.fromCharCode( 0x2028 ) + 'b"', undefined, STRICT ) )
+				.to.equal( 'a' + String.fromCharCode( 0x2028 ) + 'b' );
+			expect( parse( '"a' + String.fromCharCode( 0x2029 ) + 'b"', undefined, STRICT ) )
+				.to.equal( 'a' + String.fromCharCode( 0x2029 ) + 'b' );
 		});
 		it('still allows literal newlines inside a backtick string when esStrictCompatible', function () {
 			expect( parse( '`a\nb`', undefined, STRICT ) ).to.equal( 'a\nb' );


### PR DESCRIPTION
~~Builds on #55 .~~

feat!: reject syntax invalid in ECMAScript strict mode; fixes #46

By opt-in JSON6.parse / JSON6.begin now only accept input that is also
valid ECMAScript strict-mode syntax, so a .json6 document can be pasted
into a module or eval'd without changing meaning or raising a SyntaxError.

Newly rejected by option:
- leading-zero / legacy-octal numbers (0123)
- legacy octal string escapes ("\012", "\1".."\9")
- literal line terminators inside '' / "" strings (backticks still allow them)
- backtick-quoted object keys
- unquoted object keys that are not identifiers or numbers
- two or more consecutive unary + / - signs (--5)
- unescaped ${ } inside a backtick string

The end-of-document "// comment without end of line" warning is now silent by default.

~~BREAKING CHANGE: pass `allowNonStandard: true` to restore the lenient grammar, `forbidTemplateSubstitution: false` to accept `${` as literal text,~~ and `warnWithCommentWithoutEOL: true` to restore the comment warning.

----

~~While I could have made this non-breaking (and could still do so if that is the only way for it to be accepted), I really think it is a good idea to promote the ES-compatible approach in most applications.~~