### PR TITLE
fix: quote identifier-shaped string values in stringify

### DIFF
--- a/lib/json6.js
+++ b/lib/json6.js
@@ -1525,7 +1525,16 @@ JSON6.stringifier = function() {
 			const mind = gap;
 			/** @type {unknown} */
 			let value = holder[key];
-			if( "string" === typeof value ) value = getIdentifier( value );
+			// A string *value* must always be quoted: unlike an object key,
+			//   a bareword here would parse back as an identifier/variable
+			//   reference rather than as the string itself, so `getIdentifier`
+			//   (which intentionally leaves identifier-shaped keys unquoted)
+			//   is not applicable to values. Using it here previously emitted
+			//   invalid, non-reparseable output for any identifier-shaped
+			//   string value (e.g. `"hello"` became the bare word `hello`).
+			if( "string" === typeof value ) {
+				value = useQuote + JSON6.escape( value ) + useQuote;
+			}
 
 			if( value !== undefined
 				&& value !== null

--- a/src/json6.js
+++ b/src/json6.js
@@ -1523,7 +1523,16 @@ JSON6.stringifier = function() {
 			const mind = gap;
 			/** @type {unknown} */
 			let value = holder[key];
-			if( "string" === typeof value ) value = getIdentifier( value );
+			// A string *value* must always be quoted: unlike an object key,
+			//   a bareword here would parse back as an identifier/variable
+			//   reference rather than as the string itself, so `getIdentifier`
+			//   (which intentionally leaves identifier-shaped keys unquoted)
+			//   is not applicable to values. Using it here previously emitted
+			//   invalid, non-reparseable output for any identifier-shaped
+			//   string value (e.g. `"hello"` became the bare word `hello`).
+			if( "string" === typeof value ) {
+				value = useQuote + JSON6.escape( value ) + useQuote;
+			}
 
 			if( value !== undefined
 				&& value !== null

--- a/test/1.0.9-stringify.js
+++ b/test/1.0.9-stringify.js
@@ -35,6 +35,19 @@ describe('JSON6 stringify', function () {
 			.to.equal( '{"":"",f:false,g:0,t:true,v:NaN,w:Infinity,x:null,y:"123",z:1}' );
 	} );
 
+	it('quotes identifier-shaped string values (not just non-identifier ones)', function () {
+		// A bareword value (unlike a bareword *key*) would parse back as an
+		// identifier/variable reference rather than as the string itself, so
+		// it must always be quoted.
+		expect( JSON6.stringify( { a:'hello', b:'foo123' } ) )
+			.to.equal( '{a:"hello",b:"foo123"}' );
+	} );
+
+	it('round-trips an identifier-shaped string value through parse', function () {
+		const obj = { a:'hello', b:'true', c:'null' };
+		expect( JSON6.parse( JSON6.stringify( obj ) ) ).to.deep.equal( obj );
+	} );
+
 	it('can skip non-enumerable', function () {
 		const stringifier = JSON6.stringifier();
 		stringifier.ignoreNonEnumerable = true;


### PR DESCRIPTION
Claude AI discovered this more serious issue with stringification if you could take a look. Thanks!

----
`str()` reused `getIdentifier` -- meant only for object keys, where a bareword is valid unquoted JSON6/JS syntax -- on string values too. A value like "hello" was therefore emitted as the bare word `hello`, which parses back as an identifier/variable reference rather than as the string itself, and is not even re-parseable by JSON6.parse. String values are now always fully quoted via JSON6.escape, regardless of their shape.